### PR TITLE
Feature/unit tests/longitudinal speed planner problematic

### DIFF
--- a/simulation/traffic_simulator/test/src/behavior/test_longitudinal_speed_planner.cpp
+++ b/simulation/traffic_simulator/test/src/behavior/test_longitudinal_speed_planner.cpp
@@ -100,7 +100,6 @@ TEST(LongitudinalSpeedPlanner, getAccelerationDuration_acceleration)
 
 TEST(LongitudinalSpeedPlanner, getAccelerationDuration_zero)
 {
-  // possible negative duration, 1st issue
   auto planner = makeLongitudinalSpeedPlanner();
 
   geometry_msgs::msg::Twist current_twist{};
@@ -142,7 +141,6 @@ TEST(LongitudinalSpeedPlanner, getAccelerationDuration_zero)
 
 TEST(LongitudinalSpeedPlanner, planConstraintsFromJerkAndTimeConstraint_jerk)
 {
-  // possible sqrt of a negative number, results in a nan, 2nd issue
   auto planner = makeLongitudinalSpeedPlanner();
 
   geometry_msgs::msg::Twist current_twist{};
@@ -178,7 +176,6 @@ TEST(LongitudinalSpeedPlanner, planConstraintsFromJerkAndTimeConstraint_jerk)
 
 TEST(LongitudinalSpeedPlanner, planConstraintsFromJerkAndTimeConstraint_acceleration)
 {
-  // possible sqrt of a negative number, results in a nan, 2nd issue
   auto planner = makeLongitudinalSpeedPlanner();
 
   geometry_msgs::msg::Twist current_twist{};
@@ -217,7 +214,6 @@ TEST(LongitudinalSpeedPlanner, planConstraintsFromJerkAndTimeConstraint_accelera
 
 TEST(LongitudinalSpeedPlanner, planConstraintsFromJerkAndTimeConstraint_deceleration)
 {
-  // possible sqrt of a negative number, results in a nan, 2nd issue
   auto planner = makeLongitudinalSpeedPlanner();
 
   geometry_msgs::msg::Twist current_twist{};
@@ -442,14 +438,3 @@ TEST(LongitudinalSpeedPlanner, getRunningDistance_zero)
 
   EXPECT_EQ(distance, 0.0);
 }
-
-/*
-ISSUES:
-1: 185, 199: negative duration can be returned, possibly because
-  "getQuadraticAccelerationDurationWithConstantJerk" is being invoked if-and-only-if
-  "v" and "target_speed" is almost equal, which does not seem correct.
-  This part of the code also seems incongruent with the comments in 184, 188, 198 and 202.
-2: 59, 68: possible sqrt of a negative number.
-  "target_speed" value can overwhelm the equation. The equation itself
-  (its derivation) could not be understood.
-*/


### PR DESCRIPTION
# Description

## Abstract

This PR contains unit tests for `LongitudinalSpeedPlanner`, which is a part of traffic_simulator package.
Unit tests contained in this PR are considered **problematic and are awaiting fixes or suggestions.**

## Details
All values used for comparisons were calculated by hand.
All tests are included in `test_longitudinal_speed_planner.cpp` file.
List of tests included in this PR:

List of tests included in this PR:
1. getAccelerationDuration_zero
2. planConstraintsFromJerkAndTimeConstraint_jerk
3. planConstraintsFromJerkAndTimeConstraint_acceleration
4. planConstraintsFromJerkAndTimeConstraint_deceleration

## References
Jira ticket: [internal link](https://tier4.atlassian.net/browse/RJD-1048)

# Destructive Changes

There are no destructive changes.