### PR TITLE
Change comparison oparator in isInLanelet

### DIFF
--- a/simulation/traffic_simulator/src/utils/pose.cpp
+++ b/simulation/traffic_simulator/src/utils/pose.cpp
@@ -242,7 +242,7 @@ auto isInLanelet(
           start_lanelet_pose, canonicalized_lanelet_pose, include_adjacent_lanelet,
           include_opposite_direction, allow_lane_change, hdmap_utils_ptr);
         distance_to_start_lanelet_pose and
-        std::abs(distance_to_start_lanelet_pose.value()) < tolerance) {
+        std::abs(distance_to_start_lanelet_pose.value()) <= tolerance) {
       return true;
     }
 
@@ -252,7 +252,7 @@ auto isInLanelet(
           canonicalized_lanelet_pose, end_lanelet_pose, include_adjacent_lanelet,
           include_opposite_direction, allow_lane_change, hdmap_utils_ptr);
         distance_to_end_lanelet_pose and
-        std::abs(distance_to_end_lanelet_pose.value()) < tolerance) {
+        std::abs(distance_to_end_lanelet_pose.value()) <= tolerance) {
       return true;
     }
   }


### PR DESCRIPTION
# Description
In traffic_simulator::pose::isInLanelet comparison between distances and tolerance should be done with "<=" operator.

## Abstract

In traffic_simulator::pose::isInLanelet to compare distance_to_start_lanelet_pose and distance_to_end_lanelet_pose with tolerance operator "<" is used. This can possibly lead to wrong result when tolerance is 0 and one of the measured distances is also 0, which means pose is in lanelet (start or end of it). If this is not expected behaviour operator "<=" should be used.

## Details

> I've changed operator "<" to "<=" in traffic_simulator::pose::isInLanelet function.

# Destructive Changes

--

# Known Limitations

--
