### PR TITLE
Fix getQuadraticAccelerationDuration returning negative duration

### DIFF
--- a/simulation/traffic_simulator/src/behavior/longitudinal_speed_planning.cpp
+++ b/simulation/traffic_simulator/src/behavior/longitudinal_speed_planning.cpp
@@ -183,7 +183,7 @@ auto LongitudinalSpeedPlanner::getQuadraticAccelerationDuration(
     double v = getVelocityWithConstantJerk(
       current_twist, current_accel, constraints.max_acceleration_rate, duration);
     // While quadratic acceleration, the entity does not reached the target speed.
-    if (std::abs(v - target_speed) >= 0.01) {
+    if (v < target_speed) {
       return duration;
     }
     // While quadratic acceleration, the entity reached the target speed.
@@ -197,7 +197,7 @@ auto LongitudinalSpeedPlanner::getQuadraticAccelerationDuration(
     double v = getVelocityWithConstantJerk(
       current_twist, current_accel, -constraints.max_deceleration_rate, duration);
     // While quadratic acceleration, the entity does not reached the target speed.
-    if (std::abs(v - target_speed) >= 0.01) {
+    if (v < target_speed) {
       return duration;
     }
     // While quadratic acceleration, the entity reached the target speed.

--- a/simulation/traffic_simulator/test/src/behavior/test_longitudinal_speed_planner.cpp
+++ b/simulation/traffic_simulator/test/src/behavior/test_longitudinal_speed_planner.cpp
@@ -121,6 +121,51 @@ TEST_F(LongitudinalSpeedPlannerTest, getAccelerationDuration_acceleration)
       8.5, constraints, makeTwistWithLinearX(1.0), makeAccelWithLinearX(1.0)),
     4.0, 1e-5);
 }
+/**
+ * @note Test calculations correctness when difference between getVelocityWithConstantJerk 
+ * and target_speed is more than 0.01
+ */
+
+TEST_F(LongitudinalSpeedPlannerTest, example)
+{
+  geometry_msgs::msg::Twist current_twist{};
+  geometry_msgs::msg::Accel current_accel{};
+  current_twist.linear.x = 1.0;
+  current_accel.linear.x = 1.0;
+
+  const auto constraints =
+    traffic_simulator_msgs::build<traffic_simulator_msgs::msg::DynamicConstraints>()
+      .max_acceleration(1.0)
+      .max_acceleration_rate(1.0)
+      .max_deceleration(1.0)
+      .max_deceleration_rate(1.0)
+      .max_speed(10.0);
+
+  const double epsilon = 1e-5;
+  double target_speed, result_duration;
+
+  {
+    target_speed = current_twist.linear.x + epsilon;
+    result_duration =
+      planner.getAccelerationDuration(target_speed, constraints, current_twist, current_accel);
+    EXPECT_GE(result_duration, 0.0);
+    EXPECT_LE(result_duration, epsilon);
+  }
+  {
+    target_speed = current_twist.linear.x + 0.0100;
+    result_duration =
+      planner.getAccelerationDuration(target_speed, constraints, current_twist, current_accel);
+    EXPECT_GE(result_duration, 0.0);
+    EXPECT_LE(result_duration, 0.0100 + epsilon);
+  }
+  {
+    target_speed = current_twist.linear.x + 0.0099;
+    result_duration =
+      planner.getAccelerationDuration(target_speed, constraints, current_twist, current_accel);
+    EXPECT_GE(result_duration, 0.0);
+    EXPECT_LE(result_duration, 0.0099 + epsilon);
+  }
+}
 
 /**
  * @note Test functionality aggregation used in other classes.

--- a/simulation/traffic_simulator/test/src/behavior/test_longitudinal_speed_planner.cpp
+++ b/simulation/traffic_simulator/test/src/behavior/test_longitudinal_speed_planner.cpp
@@ -123,10 +123,10 @@ TEST_F(LongitudinalSpeedPlannerTest, getAccelerationDuration_acceleration)
 }
 /**
  * @note Test calculations correctness when difference between getVelocityWithConstantJerk 
- * and target_speed is more than 0.01
+ * and target_speed is more than 0.01, https://github.com/tier4/scenario_simulator_v2/issues/1395
  */
 
-TEST_F(LongitudinalSpeedPlannerTest, example)
+TEST_F(LongitudinalSpeedPlannerTest, getAccelerationDuration_targetSpeed_difference)
 {
   geometry_msgs::msg::Twist current_twist{};
   geometry_msgs::msg::Accel current_accel{};
@@ -141,26 +141,24 @@ TEST_F(LongitudinalSpeedPlannerTest, example)
       .max_deceleration_rate(1.0)
       .max_speed(10.0);
 
-  const double epsilon = 1e-5;
-  double target_speed, result_duration;
-
+  constexpr double epsilon = 1e-5;
   {
-    target_speed = current_twist.linear.x + epsilon;
-    result_duration =
+    const double target_speed = current_twist.linear.x + epsilon;
+    const double result_duration =
       planner.getAccelerationDuration(target_speed, constraints, current_twist, current_accel);
     EXPECT_GE(result_duration, 0.0);
     EXPECT_LE(result_duration, epsilon);
   }
   {
-    target_speed = current_twist.linear.x + 0.0100;
-    result_duration =
+    const double target_speed = current_twist.linear.x + 0.0100;
+    const double result_duration =
       planner.getAccelerationDuration(target_speed, constraints, current_twist, current_accel);
     EXPECT_GE(result_duration, 0.0);
     EXPECT_LE(result_duration, 0.0100 + epsilon);
   }
   {
-    target_speed = current_twist.linear.x + 0.0099;
-    result_duration =
+    const double target_speed = current_twist.linear.x + 0.0099;
+    const double result_duration =
       planner.getAccelerationDuration(target_speed, constraints, current_twist, current_accel);
     EXPECT_GE(result_duration, 0.0);
     EXPECT_LE(result_duration, 0.0099 + epsilon);


### PR DESCRIPTION
# Description

## Abstract
Function `getQuadraticAccelerationDuration` can return a negative duration. It is possible because `getQuadraticAccelerationDurationWithConstantJerk` is being invoked if-and-only-if `v` and `target_speed` are almost equal, which does not seem correct. This part of the code also seems incongruent with the comments in code below:

https://github.com/RobotecAI/scenario_simulator_v2/blob/a3e59a7051400776473288eceb2e4198082b4215/simulation/traffic_simulator/src/behavior/longitudinal_speed_planning.cpp#L185-L193

https://github.com/RobotecAI/scenario_simulator_v2/blob/a3e59a7051400776473288eceb2e4198082b4215/simulation/traffic_simulator/src/behavior/longitudinal_speed_planning.cpp#L197-L207

## Details
Comparison `if (std::abs(v - target_speed) >= 0.01)` in getQuadraticAccelerationDuration is changed to `if (v < target_speed) ` ensuring return duration is not negative.

## References
Jira ticket: [internal link](https://tier4.atlassian.net/browse/RJD-1337)

# Destructive Changes

There are no destructive changes.