### PR TITLE
Fix requestSpeedChange sets target_speed only when it's reached

### DIFF
--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -480,9 +480,9 @@ void EntityBase::requestSpeedChange(
           return true;
         }
         if (isTargetSpeedReached(target_speed)) {
-          target_speed_ = target_speed.getAbsoluteValue(getCanonicalizedStatus(), other_status_);
           return true;
         }
+        target_speed_ = target_speed.getAbsoluteValue(getCanonicalizedStatus(), other_status_);
         return false;
       },
       /**


### PR DESCRIPTION
# Description

## Abstract
The statement `target_speed_ = target_speed.getAbsoluteValue(getCanonicalizedStatus(), other_status_);` in firs example sets the target speed only in cases where the target speed has already been reached, which seems counter intuitive. This statement’s position is inconsistent with second example.

https://github.com/RobotecAI/scenario_simulator_v2/blob/b9317443f335edcf19fadc0b288df07010cad5f3/simulation/traffic_simulator/src/entity/entity_base.cpp#L471-L480

https://github.com/RobotecAI/scenario_simulator_v2/blob/b9317443f335edcf19fadc0b288df07010cad5f3/simulation/traffic_simulator/src/entity/entity_base.cpp#L458-L464

## Details
Described statement is moved down, outside of the “if” statement. This way the most up to date target speed will be set on each iteration until the target speed is reached. This is consistent with `continuous` case.

## References
Jira ticket: [internal link](https://tier4.atlassian.net/browse/RJD-1335)

# Destructive Changes

There are no destructive changes.