### PR TITLE
Rjd 1333/previous following lanelets

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -138,7 +138,7 @@ public:
     const lanelet::Id traffic_light_id) const -> std::optional<double>;
 
   auto getFollowingLanelets(
-    const lanelet::Id current_lanelet_id, const lanelet::Ids & route, const double horizont = 100,
+    const lanelet::Id current_lanelet_id, const lanelet::Ids & route, const double horizon = 100,
     const bool include_current_lanelet_id = true) const -> lanelet::Ids;
 
   auto getFollowingLanelets(
@@ -219,7 +219,8 @@ public:
   auto getPreviousLaneletIds(const lanelet::Id, const std::string & turn_direction) const
     -> lanelet::Ids;
 
-  auto getPreviousLanelets(const lanelet::Id, const double distance = 100) const -> lanelet::Ids;
+  auto getPreviousLanelets(const lanelet::Id, const double backward_horizon = 100) const
+    -> lanelet::Ids;
 
   auto getRightBound(const lanelet::Id) const -> std::vector<geometry_msgs::msg::Point>;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -138,8 +138,8 @@ public:
     const lanelet::Id traffic_light_id) const -> std::optional<double>;
 
   auto getFollowingLanelets(
-    const lanelet::Id lanelet_id, const lanelet::Ids & candidate_route, const double distance = 100,
-    const bool include_self = true) const -> lanelet::Ids;
+    const lanelet::Id current_lanelet_id, const lanelet::Ids & route, const double horizont = 100,
+    const bool include_current_lanelet_id = true) const -> lanelet::Ids;
 
   auto getFollowingLanelets(
     const lanelet::Id, const double distance = 100, const bool include_self = true) const

--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -138,8 +138,8 @@ public:
     const lanelet::Id traffic_light_id) const -> std::optional<double>;
 
   auto getFollowingLanelets(
-    const lanelet::Id lanelet_id, const lanelet::Ids & candidate_lanelet_ids,
-    const double distance = 100, const bool include_self = true) const -> lanelet::Ids;
+    const lanelet::Id lanelet_id, const lanelet::Ids & candidate_route, const double distance = 100,
+    const bool include_self = true) const -> lanelet::Ids;
 
   auto getFollowingLanelets(
     const lanelet::Id, const double distance = 100, const bool include_self = true) const

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -823,16 +823,16 @@ auto HdMapUtils::getFollowingLanelets(
   const lanelet::Id current_lanelet_id, const lanelet::Ids & route, const double horizon,
   const bool include_current_lanelet_id) const -> lanelet::Ids
 {
+  const auto is_following_lanelet =
+    [this](const auto & current_lanelet_id, const auto & candidate_lanelet_id) {
+      const auto next_ids = getNextLaneletIds(current_lanelet_id);
+      return std::find(next_ids.cbegin(), next_ids.cend(), candidate_lanelet_id) != next_ids.cend();
+    };
+
   lanelet::Ids following_lanelets_ids;
   if (not route.empty()) {
     double total_distance = 0.0;
     bool found_starting_lanelet = false;
-    const auto is_following_lanelet = [this](
-                                        const auto & current_lanelet_id,
-                                        const auto & candidate_lanelet_id) {
-      const auto next_ids = getNextLaneletIds(current_lanelet_id);
-      return std::find(next_ids.cbegin(), next_ids.cend(), candidate_lanelet_id) != next_ids.cend();
-    };
 
     for (const auto & candidate_lanelet_id : route) {
       if (found_starting_lanelet) {

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -820,7 +820,7 @@ auto HdMapUtils::getPreviousLanelets(const lanelet::Id lanelet_id, const double 
 
 auto HdMapUtils::isInRoute(const lanelet::Id lanelet_id, const lanelet::Ids & route) const -> bool
 {
-  return std::find(route.cbegin(), route.cend(), lanelet_id) != route.end();
+  return std::find(route.cbegin(), route.cend(), lanelet_id) != route.cend();
 }
 
 auto HdMapUtils::getFollowingLanelets(
@@ -835,7 +835,7 @@ auto HdMapUtils::getFollowingLanelets(
 
   auto lanelet_it =
     std::find(candidate_lanelet_ids.cbegin(), candidate_lanelet_ids.cend(), lanelet_id);
-  if (lanelet_it == candidate_lanelet_ids.end()) {
+  if (lanelet_it == candidate_lanelet_ids.cend()) {
     THROW_SEMANTIC_ERROR("lanelet id does not match");
   }
 
@@ -846,9 +846,9 @@ auto HdMapUtils::getFollowingLanelets(
 
   lanelet::Id previous_id{lanelet_id};
   double total_distance = 0.0;
-  for (; lanelet_it != candidate_lanelet_ids.end(); ++lanelet_it) {
+  for (; lanelet_it != candidate_lanelet_ids.cend(); ++lanelet_it) {
     if (const auto next_ids = getNextLaneletIds(previous_id);
-        std::find(next_ids.cbegin(), next_ids.cend(), *lanelet_it) == next_ids.end()) {
+        std::find(next_ids.cbegin(), next_ids.cend(), *lanelet_it) == next_ids.cend()) {
       THROW_SEMANTIC_ERROR("lanelet id does not match");
     }
     ids.emplace_back(*lanelet_it);

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -796,18 +796,21 @@ auto HdMapUtils::getPreviousLanelets(const lanelet::Id lanelet_id, const double 
 {
   lanelet::Ids ret;
   double total_distance = 0.0;
-  ret.push_back(lanelet_id);
+  lanelet::Id current_lanelet_id = lanelet_id;
+  ret.push_back(current_lanelet_id);
   while (total_distance < distance) {
-    auto ids = getPreviousLaneletIds(lanelet_id, "straight");
+    auto ids = getPreviousLaneletIds(current_lanelet_id, "straight");
     if (ids.size() != 0) {
-      total_distance = total_distance + getLaneletLength(ids[0]);
-      ret.push_back(ids[0]);
+      current_lanelet_id = ids[0];
+      total_distance = total_distance + getLaneletLength(current_lanelet_id);
+      ret.push_back(current_lanelet_id);
       continue;
     } else {
-      auto else_ids = getPreviousLaneletIds(lanelet_id);
+      auto else_ids = getPreviousLaneletIds(current_lanelet_id);
       if (else_ids.size() != 0) {
-        total_distance = total_distance + getLaneletLength(else_ids[0]);
-        ret.push_back(else_ids[0]);
+        current_lanelet_id = else_ids[0];
+        total_distance = total_distance + getLaneletLength(current_lanelet_id);
+        ret.push_back(current_lanelet_id);
         continue;
       } else {
         break;

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -824,18 +824,17 @@ auto HdMapUtils::isInRoute(const lanelet::Id lanelet_id, const lanelet::Ids & ro
 }
 
 auto HdMapUtils::getFollowingLanelets(
-  const lanelet::Id lanelet_id, const lanelet::Ids & candidate_lanelet_ids, const double distance,
+  const lanelet::Id lanelet_id, const lanelet::Ids & candidate_route, const double distance,
   const bool include_self) const -> lanelet::Ids
 {
   lanelet::Ids ids;
 
-  if (candidate_lanelet_ids.empty()) {
+  if (candidate_route.empty()) {
     return ids;
   }
 
-  auto lanelet_it =
-    std::find(candidate_lanelet_ids.cbegin(), candidate_lanelet_ids.cend(), lanelet_id);
-  if (lanelet_it == candidate_lanelet_ids.cend()) {
+  auto lanelet_it = std::find(candidate_route.cbegin(), candidate_route.cend(), lanelet_id);
+  if (lanelet_it == candidate_route.cend()) {
     THROW_SEMANTIC_ERROR("lanelet id does not match");
   }
 
@@ -846,7 +845,7 @@ auto HdMapUtils::getFollowingLanelets(
 
   lanelet::Id previous_id{lanelet_id};
   double total_distance = 0.0;
-  for (; lanelet_it != candidate_lanelet_ids.cend(); ++lanelet_it) {
+  for (; lanelet_it != candidate_route.cend(); ++lanelet_it) {
     if (const auto next_ids = getNextLaneletIds(previous_id);
         std::find(next_ids.cbegin(), next_ids.cend(), *lanelet_it) == next_ids.cend()) {
       THROW_SEMANTIC_ERROR("lanelet id does not match");
@@ -859,8 +858,7 @@ auto HdMapUtils::getFollowingLanelets(
     }
   }
   return ids + getFollowingLanelets(
-                 candidate_lanelet_ids[candidate_lanelet_ids.size() - 1], distance - total_distance,
-                 false);
+                 candidate_route[candidate_route.size() - 1], distance - total_distance, false);
 }
 
 auto HdMapUtils::getFollowingLanelets(

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -826,14 +826,19 @@ auto HdMapUtils::getFollowingLanelets(
   lanelet::Ids following_lanelets_ids;
   if (not route.empty()) {
     double total_distance = 0.0;
-    bool found_starting_lanelet{false};
+    bool found_starting_lanelet = false;
+    const auto is_following_lanelet = [this](
+                                        const auto & current_lanelet_id,
+                                        const auto & candidate_lanelet_id) {
+      const auto next_ids = getNextLaneletIds(current_lanelet_id);
+      return std::find(next_ids.cbegin(), next_ids.cend(), candidate_lanelet_id) != next_ids.cend();
+    };
+
     for (const auto & candidate_lanelet_id : route) {
       if (found_starting_lanelet) {
         const auto previous_lanelet =
           following_lanelets_ids.empty() ? current_lanelet_id : following_lanelets_ids.back();
-        if (const auto next_ids = getNextLaneletIds(previous_lanelet);
-            std::find(next_ids.cbegin(), next_ids.cend(), candidate_lanelet_id) ==
-            next_ids.cend()) {
+        if (not is_following_lanelet(previous_lanelet, candidate_lanelet_id)) {
           THROW_SEMANTIC_ERROR(
             candidate_lanelet_id + " is not the follower of lanelet " + previous_lanelet);
         }

--- a/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
+++ b/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
@@ -2616,3 +2616,15 @@ TEST_F(HdMapUtilsTest_CrossroadsWithStoplinesMap, getDistanceToStopLine_emptyVec
           makePoint(3807.63, 73715.99), makePoint(3785.76, 73707.70), makePoint(3773.19, 73723.27)})
       .has_value());
 }
+
+/**
+ * @note Test basic functionality.
+ */
+TEST_F(HdMapUtilsTest_StandardMap, getPreviousLanelets)
+{
+  const lanelet::Id id = 34600;
+  const auto result_previous = hdmap_utils.getPreviousLanelets(id, 100.0);
+  const lanelet::Ids actual_previous{id, 34783, 34606, 34795, 34507};
+
+  EXPECT_EQ(result_previous, actual_previous);
+}

--- a/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
+++ b/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
@@ -1599,6 +1599,19 @@ TEST_F(HdMapUtilsTest_StandardMap, getFollowingLanelets_candidateTrajectory)
 
 /**
  * @note Test basic functionality.
+ * Test following lanelets obtaining
+ * with a candidate trajectory longer than the given distance without starting lanelet.
+ */
+TEST_F(HdMapUtilsTest_StandardMap, getFollowingLanelets_candidateTrajectoryFalse)
+{
+  const lanelet::Id id = 34564;
+  EXPECT_EQ(
+    hdmap_utils.getFollowingLanelets(id, lanelet::Ids{id, 34495, 34507, 34795, 34606}, 40.0, false),
+    (lanelet::Ids{34495, 34507}));
+}
+
+/**
+ * @note Test basic functionality.
  * Test following lanelets obtaining with
  * a candidate trajectory shorter than the given distance
  * - the goal is to test generating lacking part of the trajectory.

--- a/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
+++ b/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
@@ -1631,6 +1631,18 @@ TEST_F(HdMapUtilsTest_StandardMap, getFollowingLanelets_candidateTrajectoryEmpty
 }
 
 /**
+ * @note Test function behavior when called with a candidate trajectory
+ * that contains wrong candidates
+ */
+TEST_F(HdMapUtilsTest_StandardMap, getFollowingLanelets_candidatesDoNotMatchRealTrajectory)
+{
+  EXPECT_THROW(
+    hdmap_utils.getFollowingLanelets(
+      34564, lanelet::Ids{34564, 34495, 34507, 34399, 34399}, 100.0, true),
+    common::Error);
+}
+
+/**
  * @note Test basic functionality.
  * Test lane change possibility checking
  * correctness with lanelets that can be changed.


### PR DESCRIPTION
# Description

## Abstract
Function `getFollowingLanelets` has confusing functionality or imprecise naming. Consider the following invocation: `getFollowingLanelets(120660, {120660, <random-lanelets>}, 10000, true)`, then will be added to the returned vector unconditionally.
Function `getPreviousLanelets` has a mistake. The function is supposed to process one lanelet in every iteration, but every iteration starts from the lanelet passed as the argument. The result will be the lanelet passed as the argument and many copies of the one - previous lanelet. The mistake was introduced in change https://github.com/tier4/scenario_simulator_v2/commit/3fc8c0ad9f6aaf0762b16c0cb168e1dfcbf1ed29#diff-da44510bdbbba766d1ba47318640cfd8bcff2e350eafe3d77d364bfbf70e25cdL745-L770. The previous implementation seems to have been right.

## Details
Function `getFollowingLanelets` was changed to check if candidates lanelets are actually following each other.
Function `getPreviousLanelets` was rewritten to match previous implementation.

## References
Jira ticket: [internal link](https://tier4.atlassian.net/browse/RJD-1333)

# Destructive Changes

There are no destructive changes.