### PR TITLE
RJD-1509 ActionNode methods optimization

### DIFF
--- a/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
@@ -50,14 +50,15 @@ public:
   auto getSquaredDistanceVector(const geometry_msgs::msg::Point & point, const double s) const
     -> geometry_msgs::msg::Vector3;
   auto getCollisionPointsIn2D(
-    const std::vector<geometry_msgs::msg::Point> & polygon,
-    const bool search_backward = false) const -> std::set<double>;
+    const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
+    std::optional<std::pair<double, double>> s_part = std::nullopt) const -> std::set<double>;
   auto getCollisionPointIn2D(
     const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
     const bool search_backward = false) const -> std::optional<double>;
   auto getCollisionPointIn2D(
-    const std::vector<geometry_msgs::msg::Point> & polygon,
-    const bool search_backward = false) const -> std::optional<double> override;
+    const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
+    std::optional<std::pair<double, double>> s_part = std::nullopt) const
+    -> std::optional<double> override;
   auto getPolygon(const double width, const size_t num_points = 30, const double z_offset = 0)
     -> std::vector<geometry_msgs::msg::Point>;
   const std::vector<geometry_msgs::msg::Point> control_points;

--- a/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
@@ -51,13 +51,14 @@ public:
     -> geometry_msgs::msg::Vector3;
   auto getCollisionPointsIn2D(
     const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
-    std::optional<std::pair<double, double>> s_part = std::nullopt) const -> std::set<double>;
+    const std::optional<std::pair<double, double>> & s_range = std::nullopt) const
+    -> std::set<double>;
   auto getCollisionPointIn2D(
     const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
     const bool search_backward = false) const -> std::optional<double>;
   auto getCollisionPointIn2D(
     const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
-    std::optional<std::pair<double, double>> s_part = std::nullopt) const
+    const std::optional<std::pair<double, double>> & s_range = std::nullopt) const
     -> std::optional<double> override;
   auto getPolygon(const double width, const size_t num_points = 30, const double z_offset = 0)
     -> std::vector<geometry_msgs::msg::Point>;

--- a/common/math/geometry/include/geometry/spline/catmull_rom_spline_interface.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_spline_interface.hpp
@@ -32,8 +32,8 @@ public:
   virtual ~CatmullRomSplineInterface() = default;
   virtual double getLength() const = 0;
   virtual std::optional<double> getCollisionPointIn2D(
-    const std::vector<geometry_msgs::msg::Point> & polygon,
-    const bool search_backward = false) const = 0;
+    const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
+    std::optional<std::pair<double, double>> s_part = std::nullopt) const = 0;
   virtual double getSquaredDistanceIn2D(
     const geometry_msgs::msg::Point & point, const double s) const = 0;
 };

--- a/common/math/geometry/include/geometry/spline/catmull_rom_spline_interface.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_spline_interface.hpp
@@ -33,7 +33,7 @@ public:
   virtual double getLength() const = 0;
   virtual std::optional<double> getCollisionPointIn2D(
     const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
-    std::optional<std::pair<double, double>> s_part = std::nullopt) const = 0;
+    const std::optional<std::pair<double, double>> & s_range = std::nullopt) const = 0;
   virtual double getSquaredDistanceIn2D(
     const geometry_msgs::msg::Point & point, const double s) const = 0;
 };

--- a/common/math/geometry/include/geometry/spline/catmull_rom_subspline.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_subspline.hpp
@@ -43,8 +43,8 @@ public:
   double getLength() const override;
 
   std::optional<double> getCollisionPointIn2D(
-    const std::vector<geometry_msgs::msg::Point> & polygon,
-    const bool search_backward = false) const override;
+    const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
+    std::optional<std::pair<double, double>> s_part = std::nullopt) const override;
 
   auto getSquaredDistanceIn2D(const geometry_msgs::msg::Point & point, const double s) const
     -> double override;

--- a/common/math/geometry/include/geometry/spline/catmull_rom_subspline.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_subspline.hpp
@@ -44,7 +44,7 @@ public:
 
   std::optional<double> getCollisionPointIn2D(
     const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward = false,
-    std::optional<std::pair<double, double>> s_part = std::nullopt) const override;
+    const std::optional<std::pair<double, double>> & s_range = std::nullopt) const override;
 
   auto getSquaredDistanceIn2D(const geometry_msgs::msg::Point & point, const double s) const
     -> double override;

--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -27,7 +27,7 @@ namespace math
 namespace geometry
 {
 auto CatmullRomSpline::getPolygon(
-  const double width, const size_t num_points, const double z_offset)
+  const double width, const std::size_t num_points, const double z_offset)
   -> std::vector<geometry_msgs::msg::Point>
 {
   if (num_points == 0) {
@@ -36,7 +36,7 @@ auto CatmullRomSpline::getPolygon(
   std::vector<geometry_msgs::msg::Point> points;
   std::vector<geometry_msgs::msg::Point> left_bounds = getLeftBounds(width, num_points, z_offset);
   std::vector<geometry_msgs::msg::Point> right_bounds = getRightBounds(width, num_points, z_offset);
-  for (size_t i = 0; i < left_bounds.size() - 1; i++) {
+  for (std::size_t i = 0; i < left_bounds.size() - 1; i++) {
     geometry_msgs::msg::Point pr_0 = right_bounds[i];
     geometry_msgs::msg::Point pl_0 = left_bounds[i];
     geometry_msgs::msg::Point pr_1 = right_bounds[i + 1];
@@ -52,12 +52,12 @@ auto CatmullRomSpline::getPolygon(
 }
 
 auto CatmullRomSpline::getRightBounds(
-  const double width, const size_t num_points, const double z_offset) const
+  const double width, const std::size_t num_points, const double z_offset) const
   -> std::vector<geometry_msgs::msg::Point>
 {
   std::vector<geometry_msgs::msg::Point> points;
   double step_size = getLength() / static_cast<double>(num_points);
-  for (size_t i = 0; i < num_points + 1; i++) {
+  for (std::size_t i = 0; i < num_points + 1; i++) {
     double s = step_size * static_cast<double>(i);
     points.emplace_back(
       [this](const double local_width, const double local_s, const double local_z_offset) {
@@ -75,12 +75,12 @@ auto CatmullRomSpline::getRightBounds(
 }
 
 auto CatmullRomSpline::getLeftBounds(
-  const double width, const size_t num_points, const double z_offset) const
+  const double width, const std::size_t num_points, const double z_offset) const
   -> std::vector<geometry_msgs::msg::Point>
 {
   std::vector<geometry_msgs::msg::Point> points;
   double step_size = getLength() / static_cast<double>(num_points);
-  for (size_t i = 0; i < num_points + 1; i++) {
+  for (std::size_t i = 0; i < num_points + 1; i++) {
     double s = step_size * static_cast<double>(i);
     points.emplace_back(
       [this](const double local_width, const double local_s, const double local_z_offset) {
@@ -142,8 +142,8 @@ CatmullRomSpline::CatmullRomSpline(const std::vector<geometry_msgs::msg::Point> 
     /// @note In this case, spline is interpreted as curve.
     default:
       [this](const auto & control_points) -> void {
-        size_t n = control_points.size() - 1;
-        for (size_t i = 0; i < n; i++) {
+        std::size_t n = control_points.size() - 1;
+        for (std::size_t i = 0; i < n; i++) {
           if (i == 0) {
             double ax = 0;
             double bx = control_points[0].x - 2 * control_points[1].x + control_points[2].x;
@@ -244,7 +244,7 @@ CatmullRomSpline::CatmullRomSpline(const std::vector<geometry_msgs::msg::Point> 
   }
 }
 
-auto CatmullRomSpline::getCurveIndexAndS(const double s) const -> std::pair<size_t, double>
+auto CatmullRomSpline::getCurveIndexAndS(const double s) const -> std::pair<std::size_t, double>
 {
   if (s < 0) {
     return std::make_pair(0, s);
@@ -254,7 +254,7 @@ auto CatmullRomSpline::getCurveIndexAndS(const double s) const -> std::pair<size
       curves_.size() - 1, s - (total_length_ - curves_[curves_.size() - 1].getLength()));
   }
   double current_s = 0;
-  for (size_t i = 0; i < curves_.size(); i++) {
+  for (std::size_t i = 0; i < curves_.size(); i++) {
     double prev_s = current_s;
     current_s = current_s + length_list_[i];
     if (prev_s <= s && s < current_s) {
@@ -264,11 +264,12 @@ auto CatmullRomSpline::getCurveIndexAndS(const double s) const -> std::pair<size
   THROW_SIMULATION_ERROR("failed to calculate curve index");  // LCOV_EXCL_LINE
 }
 
-auto CatmullRomSpline::getSInSplineCurve(const size_t curve_index, const double s) const -> double
+auto CatmullRomSpline::getSInSplineCurve(const std::size_t curve_index, const double s) const
+  -> double
 {
-  size_t n = curves_.size();
+  std::size_t n = curves_.size();
   double ret = 0;
-  for (size_t i = 0; i < n; i++) {
+  for (std::size_t i = 0; i < n; i++) {
     if (i == curve_index) {
       return ret + s;
     } else {
@@ -295,7 +296,7 @@ auto CatmullRomSpline::getCollisionPointsIn2D(
                                                    const auto local_search_backward) {
     std::set<double> s_value_candidates;
     auto current_curve_start_s = 0.0;
-    for (size_t i = 0; i < curves_.size(); ++i) {
+    for (std::size_t i = 0; i < curves_.size(); ++i) {
       if (
         s_range == std::nullopt ||
         (current_curve_start_s >= s_range->first && current_curve_start_s <= s_range->second)) {
@@ -383,9 +384,9 @@ auto CatmullRomSpline::getCollisionPointIn2D(
   const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
   const bool search_backward) const -> std::optional<double>
 {
-  size_t n = curves_.size();
+  std::size_t n = curves_.size();
   if (search_backward) {
-    for (size_t i = 0; i < n; i++) {
+    for (std::size_t i = 0; i < n; i++) {
       auto s = curves_[n - 1 - i].getCollisionPointIn2D(point0, point1, search_backward, true);
       if (s) {
         return getSInSplineCurve(n - 1 - i, s.value());
@@ -393,7 +394,7 @@ auto CatmullRomSpline::getCollisionPointIn2D(
     }
     return std::nullopt;
   } else {
-    for (size_t i = 0; i < n; i++) {
+    for (std::size_t i = 0; i < n; i++) {
       auto s = curves_[i].getCollisionPointIn2D(point0, point1, search_backward, true);
       if (s) {
         return getSInSplineCurve(i, s.value());
@@ -435,7 +436,7 @@ auto CatmullRomSpline::getSValue(
       return line_segments_[0].getSValue(pose, threshold_distance, true);
     default:
       double s = 0;
-      for (size_t i = 0; i < curves_.size(); i++) {
+      for (std::size_t i = 0; i < curves_.size(); i++) {
         auto s_value = curves_[i].getSValue(pose, threshold_distance, true);
         if (s_value) {
           s = s + s_value.value();
@@ -692,7 +693,7 @@ auto CatmullRomSpline::checkConnection() const -> bool
     THROW_SIMULATION_ERROR(                                    // LCOV_EXCL_LINE
       "number of control points and curves does not match.");  // LCOV_EXCL_LINE
   }
-  for (size_t i = 0; i < curves_.size(); i++) {
+  for (std::size_t i = 0; i < curves_.size(); i++) {
     const auto control_point0 = control_points[i];
     const auto control_point1 = control_points[i + 1];
     const auto p0 = curves_[i].getPoint(0, false);

--- a/common/math/geometry/src/spline/catmull_rom_subspline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_subspline.cpp
@@ -25,7 +25,7 @@ double CatmullRomSubspline::getLength() const { return end_s_ - start_s_; }
 
 std::optional<double> CatmullRomSubspline::getCollisionPointIn2D(
   const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward,
-  std::optional<std::pair<double, double>> s_part) const
+  const std::optional<std::pair<double, double>> & s_range) const
 {
   /// @note Make sure end is greater than start, otherwise the spline is invalid
   if (end_s_ < start_s_) {
@@ -38,7 +38,8 @@ std::optional<double> CatmullRomSubspline::getCollisionPointIn2D(
       "contact the developer of traffic_simulator.");
   }
 
-  std::set<double> s_value_candidates = spline_->getCollisionPointsIn2D(polygon, false, s_part);
+  std::set<double> s_value_candidates =
+    spline_->getCollisionPointsIn2D(polygon, search_backward, s_range);
 
   if (s_value_candidates.empty()) {
     return std::nullopt;

--- a/common/math/geometry/src/spline/catmull_rom_subspline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_subspline.cpp
@@ -24,7 +24,8 @@ namespace geometry
 double CatmullRomSubspline::getLength() const { return end_s_ - start_s_; }
 
 std::optional<double> CatmullRomSubspline::getCollisionPointIn2D(
-  const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward) const
+  const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward,
+  std::optional<std::pair<double, double>> s_part) const
 {
   /// @note Make sure end is greater than start, otherwise the spline is invalid
   if (end_s_ < start_s_) {
@@ -37,7 +38,7 @@ std::optional<double> CatmullRomSubspline::getCollisionPointIn2D(
       "contact the developer of traffic_simulator.");
   }
 
-  std::set<double> s_value_candidates = spline_->getCollisionPointsIn2D(polygon);
+  std::set<double> s_value_candidates = spline_->getCollisionPointsIn2D(polygon, false, s_part);
 
   if (s_value_candidates.empty()) {
     return std::nullopt;

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -331,26 +331,21 @@ auto ActionNode::getDistanceToTargetEntity(
       target_lanelet_pose) {
     const auto & from_lanelet_pose = canonicalized_entity_status->getCanonicalizedLaneletPose();
     const auto & from_bounding_box = canonicalized_entity_status->getBoundingBox();
-    if (const auto bounding_box_distance =
-          traffic_simulator::distance::boundingBoxLaneLongitudinalDistance(
+    if (const auto bounding_box_distances =
+          traffic_simulator::distance::laneLongitudinalDistances(
             *from_lanelet_pose, from_bounding_box, *target_lanelet_pose, target_bounding_box,
             include_adjacent_lanelet, include_opposite_direction, routing_configuration,
             hdmap_utils);
-        !bounding_box_distance || bounding_box_distance.value() < 0.0) {
-      return std::nullopt;
-    } else if (const auto position_distance = traffic_simulator::distance::longitudinalDistance(
-                 *from_lanelet_pose, *target_lanelet_pose, include_adjacent_lanelet,
-                 include_opposite_direction, routing_configuration, hdmap_utils);
-               !position_distance) {
+        !bounding_box_distances || bounding_box_distances.value().first < 0.0) {
       return std::nullopt;
     } else {
       const auto target_bounding_box_distance =
-        bounding_box_distance.value() + from_bounding_box.dimensions.x / 2.0;
+        bounding_box_distances.value().first + from_bounding_box.dimensions.x / 2.0;
 
       /// @note if the distance of the target entity to the spline is smaller than the width of the reference entity
       if (const auto target_to_spline_distance = traffic_simulator::distance::distanceToSpline(
             static_cast<geometry_msgs::msg::Pose>(*target_lanelet_pose), target_bounding_box,
-            spline, position_distance.value());
+            spline, bounding_box_distances.value().second);
           target_to_spline_distance <= from_bounding_box.dimensions.y / 2.0) {
         return target_bounding_box_distance;
       }

--- a/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
@@ -71,14 +71,10 @@ auto boundingBoxLaneLongitudinalDistance(
   const traffic_simulator::RoutingConfiguration & routing_configuration,
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;
 
-auto laneLongitudinalDistances(
-  const CanonicalizedLaneletPose & from,
+auto boundingBoxLaneLongitudinalDistance(
+  const std::optional<double> & longitudinal_distance,
   const traffic_simulator_msgs::msg::BoundingBox & from_bounding_box,
-  const CanonicalizedLaneletPose & to,
-  const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box, bool include_adjacent_lanelet,
-  bool include_opposite_direction,
-  const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<std::pair<double,double>>;
+  const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box) -> std::optional<double>;
 
 // Bounds
 auto distanceToLaneBound(

--- a/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
@@ -71,6 +71,15 @@ auto boundingBoxLaneLongitudinalDistance(
   const traffic_simulator::RoutingConfiguration & routing_configuration,
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;
 
+auto laneLongitudinalDistances(
+  const CanonicalizedLaneletPose & from,
+  const traffic_simulator_msgs::msg::BoundingBox & from_bounding_box,
+  const CanonicalizedLaneletPose & to,
+  const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box, bool include_adjacent_lanelet,
+  bool include_opposite_direction,
+  const traffic_simulator::RoutingConfiguration & routing_configuration,
+  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<std::pair<double,double>>;
+
 // Bounds
 auto distanceToLaneBound(
   const geometry_msgs::msg::Pose & map_pose,

--- a/simulation/traffic_simulator/src/utils/distance.cpp
+++ b/simulation/traffic_simulator/src/utils/distance.cpp
@@ -197,19 +197,12 @@ auto boundingBoxLaneLongitudinalDistance(
   return std::nullopt;
 }
 
-auto laneLongitudinalDistances(
-  const CanonicalizedLaneletPose & from,
+auto boundingBoxLaneLongitudinalDistance(
+  const std::optional<double> & longitudinal_distance,
   const traffic_simulator_msgs::msg::BoundingBox & from_bounding_box,
-  const CanonicalizedLaneletPose & to,
-  const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box, bool include_adjacent_lanelet,
-  bool include_opposite_direction,
-  const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<std::pair<double,double>>
+  const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box) -> std::optional<double>
 {
-  if (const auto longitudinal_distance = longitudinalDistance(
-        from, to, include_adjacent_lanelet, include_opposite_direction, routing_configuration,
-        hdmap_utils_ptr);
-      longitudinal_distance) {
+  if (longitudinal_distance) {
     const auto from_bounding_box_distances =
       math::geometry::getDistancesFromCenterToEdge(from_bounding_box);
     const auto to_bounding_box_distances =
@@ -222,7 +215,7 @@ auto laneLongitudinalDistances(
       bounding_box_distance =
         +std::abs(from_bounding_box_distances.rear) + std::abs(to_bounding_box_distances.front);
     }
-    return std::make_pair(longitudinal_distance.value() + bounding_box_distance, longitudinal_distance.value());
+    return longitudinal_distance.value() + bounding_box_distance;
   }
   return std::nullopt;
 }


### PR DESCRIPTION
# Description

In ActionNode used methods distance::boundingBoxLaneLongitudinalDistance and CatmullRomSpline::getCollisionPointIn2D can be optimized.

## Abstract

In ActionNode::getDistanceToTargetEntity needs boundingBoxLaneLongitudinalDistance and longitudinalDistance, both are calculated with boundingBoxLaneLongitudinalDistance, but only one is returned.

In ActionNode::getDistanceToTargetEntity CatmullRomSpline::getCollisionPointIn2D check all length of spline for collision points, knowing longitudinalDistance to conflicting entity we can check only small part of it.

## Details

In ActionNode::getDistanceToTargetEntity:
 - use newly defined traffic_simulator::distance::laneLongitudinalDistances, which returns pair of boundingBoxLaneLongitudinalDistance and longitudinalDistance
 - use changed CatmullRomSpline::getCollisionPointIn2D with defined part of spline to check for collision

# Destructive Changes
--

# Known Limitations
--

## References
[RJD-1509](https://tier4.atlassian.net/browse/RJD-1509)
