### PR TITLE
RJD-1509 Filter nearest NPCs to calculate distance

### DIFF
--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
@@ -86,6 +86,7 @@ public:
       BT::InputPort<std::shared_ptr<traffic_simulator::CanonicalizedEntityStatus>>("canonicalized_entity_status"),
       BT::InputPort<std::shared_ptr<traffic_simulator::TrafficLightsBase>>("traffic_lights"),
       BT::InputPort<traffic_simulator::behavior::Request>("request"),
+      BT::InputPort<std::shared_ptr<DistancesMap>>("distances_map"),
       BT::OutputPort<std::optional<traffic_simulator_msgs::msg::Obstacle>>("obstacle"),
       BT::OutputPort<traffic_simulator_msgs::msg::WaypointsArray>("waypoints"),
       BT::OutputPort<traffic_simulator::behavior::Request>("request"),
@@ -116,6 +117,7 @@ protected:
   std::optional<double> target_speed;
   EntityStatusDict other_entity_status;
   lanelet::Ids route_lanelets;
+  std::shared_ptr<DistancesMap> distances_map;
 
   auto getDistanceToTargetEntity(
     const math::geometry::CatmullRomSplineInterface & spline,

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
@@ -70,6 +70,7 @@ public:
   DEFINE_GETTER_SETTER(TrafficLights,                                    std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
+  DEFINE_GETTER_SETTER(DistancesMap,                                     std::shared_ptr<DistancesMap>)
   // clang-format on
 
 #undef DEFINE_GETTER_SETTER

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
@@ -74,6 +74,7 @@ public:
   DEFINE_GETTER_SETTER(TrafficLights,                                    std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
+  DEFINE_GETTER_SETTER(DistancesMap,                                     std::shared_ptr<DistancesMap>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
+++ b/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
@@ -58,6 +58,7 @@ public:                                         \
   DEFINE_GETTER_SETTER(TrafficLights,                                    std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
+  DEFINE_GETTER_SETTER(DistancesMap,                                     std::shared_ptr<DistancesMap>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
@@ -36,6 +36,8 @@ namespace entity_behavior
 using EntityStatusDict =
   std::unordered_map<std::string, traffic_simulator::CanonicalizedEntityStatus>;
 
+using DistancesMap = std::unordered_map<std::pair<std::string, std::string>, double>;
+
 class BehaviorPluginBase
 {
 public:
@@ -44,13 +46,13 @@ public:
   virtual auto update(const double current_time, const double step_time) -> void = 0;
   virtual const std::string & getCurrentAction() const = 0;
 
-#define DEFINE_GETTER_SETTER(NAME, KEY, TYPE)      \
-  virtual TYPE get##NAME() = 0;                    \
-  virtual void set##NAME(const TYPE & value) = 0;  \
-  auto get##NAME##Key() const->const std::string & \
-  {                                                \
-    static const std::string key = KEY;            \
-    return key;                                    \
+#define DEFINE_GETTER_SETTER(NAME, KEY, TYPE)        \
+  virtual TYPE get##NAME() = 0;                      \
+  virtual void set##NAME(const TYPE & value) = 0;    \
+  auto get##NAME##Key() const -> const std::string & \
+  {                                                  \
+    static const std::string key = KEY;              \
+    return key;                                      \
   }
 
   // clang-format off
@@ -74,6 +76,7 @@ public:
   DEFINE_GETTER_SETTER(TrafficLights,                                    "traffic_lights",                                 std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                "vehicle_parameters",                             traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        "waypoints",                                      traffic_simulator_msgs::msg::WaypointsArray)
+  DEFINE_GETTER_SETTER(DistancesMap,                                     "distances_map",                                  std::shared_ptr<DistancesMap>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 };

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -47,6 +47,7 @@ namespace traffic_simulator
 {
 namespace entity
 {
+using DistancesMap = std::unordered_map<std::pair<std::string, std::string>, double>;
 class EntityBase : public std::enable_shared_from_this<EntityBase>
 {
 public:
@@ -312,6 +313,8 @@ public:
 
   bool verbose;
 
+  void setDistances(const std::shared_ptr<DistancesMap> & distances);
+
 protected:
   std::shared_ptr<CanonicalizedEntityStatus> status_;
 
@@ -332,6 +335,8 @@ protected:
 
   std::unique_ptr<traffic_simulator::longitudinal_speed_planning::LongitudinalSpeedPlanner>
     speed_planner_;
+
+  std::shared_ptr<DistancesMap> distances_map_;
 
 private:
   virtual auto requestSpeedChangeWithConstantAcceleration(

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -93,8 +93,9 @@ public:
   // update
   auto update(const double current_time, const double step_time) -> void;
 
-  auto updateNpcLogic(const std::string & name, const double current_time, const double step_time)
-    -> const CanonicalizedEntityStatus &;
+  auto updateNpcLogic(
+    const std::string & name, const double current_time, const double step_time,
+    const std::shared_ptr<DistancesMap> distances) -> const CanonicalizedEntityStatus &;
 
   auto updateHdmapMarker() const -> void;
 

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -851,5 +851,10 @@ auto EntityBase::requestSynchronize(
   return false;
 }
 
+void EntityBase::setDistances(const std::shared_ptr<DistancesMap> & distances)
+{
+  distances_map_ = distances;
+}
+
 }  // namespace entity
 }  // namespace traffic_simulator

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <geometry/distance.hpp>
 #include <geometry/vector3/operator.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <traffic_simulator/entity/entity_manager.hpp>
@@ -75,8 +76,20 @@ auto EntityManager::update(const double current_time, const double step_time) ->
     entity_ptr->setOtherStatus(all_status);
   }
   all_status.clear();
+
+  std::shared_ptr<DistancesMap> distances = std::make_shared<DistancesMap>();
+  for (auto && [name_from, entity_from] : entities_) {
+    for (auto && [name_to, entity_to] : entities_) {
+      if (const auto pair = std::minmax(name_from, name_to);
+          distances->find(pair) == distances->end() && name_from != name_to) {
+        distances->emplace(
+          pair, math::geometry::getDistance(entity_from->getMapPose(), entity_to->getMapPose()));
+      }
+    }
+  }
+
   for (const auto & [name, entity_ptr] : entities_) {
-    all_status.try_emplace(name, updateNpcLogic(name, current_time, step_time));
+    all_status.try_emplace(name, updateNpcLogic(name, current_time, step_time, distances));
   }
   for (const auto & [name, entity_ptr] : entities_) {
     entity_ptr->setOtherStatus(all_status);
@@ -108,8 +121,8 @@ auto EntityManager::update(const double current_time, const double step_time) ->
 }
 
 auto EntityManager::updateNpcLogic(
-  const std::string & name, const double current_time, const double step_time)
-  -> const CanonicalizedEntityStatus &
+  const std::string & name, const double current_time, const double step_time,
+  const std::shared_ptr<DistancesMap> distances) -> const CanonicalizedEntityStatus &
 {
   if (configuration_.verbose) {
     std::cout << "update " << name << " behavior" << std::endl;
@@ -117,6 +130,7 @@ auto EntityManager::updateNpcLogic(
   auto & entity = getEntity(name);
   // Update npc completely if logic has started, otherwise update Autoware only - if it is Ego
   if (npc_logic_started_) {
+    entity.setDistances(distances);
     entity.onUpdate(current_time, step_time);
   } else if (entity.is<entity::EgoEntity>()) {
     getEgoEntity(name).updateFieldOperatorApplication();

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -140,6 +140,7 @@ auto VehicleEntity::onUpdate(const double current_time, const double step_time) 
   behavior_plugin_ptr_->setTargetSpeed(target_speed_);
   auto route_lanelets = getRouteLanelets();
   behavior_plugin_ptr_->setRouteLanelets(route_lanelets);
+  behavior_plugin_ptr_->setDistancesMap(distances_map_);
 
   // recalculate spline only when input data changes
   if (previous_route_lanelets_ != route_lanelets) {


### PR DESCRIPTION
# Description

This PR  implements optimization of calculating actual distance in ActionNode::getDistanceToTargetEntity only for nearest NPCs.

## Abstract

ActionNode::getDistanceToTargetEntity should calculate boundingBoxLaneLongitudinalDistance only for nearest NPC. This is done based on DistancesMap containg shortest distance between mapPose of NPCs.

## Details

1. Rough distance between all NPCs is calculated only once for each update in EntityManager.
2. sharred_ptr of this map is passed to behavior_tree and used ActionNode::getDistanceToTargetEntity.
3. Nearest NPCs are NPCs in distance of NPC spline length.

# Destructive Changes
--

# Known Limitations
--

## References
[RJD-1509](https://tier4.atlassian.net/browse/RJD-1509)