### PR TITLE
RJD-1769 Force centerline creation

### DIFF
--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -1080,10 +1080,8 @@ auto HdMapUtils::generateMarker() const -> visualization_msgs::msg::MarkerArray
 auto HdMapUtils::overwriteLaneletsCenterline() -> void
 {
   for (auto & lanelet_obj : lanelet_map_ptr_->laneletLayer) {
-    if (!lanelet_obj.hasCustomCenterline()) {
-      const auto fine_center_line = generateFineCenterline(lanelet_obj, 2.0);
-      lanelet_obj.setCenterline(fine_center_line);
-    }
+    const auto fine_center_line = generateFineCenterline(lanelet_obj, 2.0);
+    lanelet_obj.setCenterline(fine_center_line);
   }
 }
 

--- a/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_loader.cpp
+++ b/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_loader.cpp
@@ -77,11 +77,8 @@ auto LaneletLoader::overwriteLaneletsCenterline(lanelet::LaneletMapPtr lanelet_m
     }
     return centerline;
   };
-
   for (auto & lanelet_obj : lanelet_map_ptr->laneletLayer) {
-    if (!lanelet_obj.hasCustomCenterline()) {
-      lanelet_obj.setCenterline(generateFineCenterline(lanelet_obj));
-    }
+    lanelet_obj.setCenterline(generateFineCenterline(lanelet_obj));
   }
 }
 


### PR DESCRIPTION
# Description

## Abstract

This PR forces creation of centerline for all lanelets basing on left and right bound even if centerline is defined in map.

## Details

1. Removed checking if lanelet has custom centerline in LaneletLoader.
2. Removed checking if lanelet has custom centerline in HdMapUtils.

# Destructive Changes
--

# Known Limitations
--

## References
[RJD-1769](https://tier4.atlassian.net/browse/RJD-1769)