### PR TITLE
RJD-1907 Add support for vehicle_id and initialize_localization

### DIFF
--- a/external/concealer/src/field_operator_application.cpp
+++ b/external/concealer/src/field_operator_application.cpp
@@ -155,7 +155,7 @@ FieldOperatorApplication::FieldOperatorApplication(const pid_t pid)
   requestClearRoute("/api/routing/clear_route", *this),
   requestCooperateCommands("/api/external/set/rtc_commands", *this),
   requestEngage("/api/external/set/engage", *this),
-  requestInitialPose("/api/localization/initialize", *this),
+  requestInitialPose("/api/localization/initialize", *this, std::chrono::seconds(common::getParameter<int>("initialize_localization"))),
   // NOTE: routing takes a long time to return. But the specified duration is not decided by any technical reasons.
   requestSetRoute("/api/routing/set_route", *this, std::chrono::seconds(10)),
   requestSetRoutePoints("/api/routing/set_route_points", *this, std::chrono::seconds(10)),

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -46,17 +46,16 @@ EgoEntity::EgoEntity(
       auto parameters =
         common::getParameter<std::vector<std::string>>(node_parameters, "autoware.", {});
       const std::string vehicle_id;
-      // clang-format off
-      try{
+
+      try {
          vehicle_id = common::getParameter<std::string>(node_parameters, "vehicle_id"));
-      } catch (...)
-      {
+      } catch (...) {
         vehicle_id = std::to_string(common::getParameter<int>(node_parameters, "vehicle_id"));
       }
-      if(vehicle_id != "default" && !vehicle_id.empty())
-      {
+      if (vehicle_id != "default" && !vehicle_id.empty()) {
         parameters.push_back("vehicle_id:=" + vehicle_id);
       }
+      // clang-format off
       parameters.push_back("map_path:=" + configuration.map_path.string());
       parameters.push_back("lanelet2_map_file:=" + configuration.getLanelet2MapFile());
       parameters.push_back("pointcloud_map_file:=" + configuration.getPointCloudMapFile());

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -45,10 +45,10 @@ EgoEntity::EgoEntity(
         architecture_type.find("awf/universe") != std::string::npos) {
       auto parameters =
         common::getParameter<std::vector<std::string>>(node_parameters, "autoware.", {});
-      const std::string vehicle_id;
+      std::string vehicle_id;
 
       try {
-         vehicle_id = common::getParameter<std::string>(node_parameters, "vehicle_id"));
+        vehicle_id = common::getParameter<std::string>(node_parameters, "vehicle_id");
       } catch (...) {
         vehicle_id = std::to_string(common::getParameter<int>(node_parameters, "vehicle_id"));
       }

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -45,8 +45,18 @@ EgoEntity::EgoEntity(
         architecture_type.find("awf/universe") != std::string::npos) {
       auto parameters =
         common::getParameter<std::vector<std::string>>(node_parameters, "autoware.", {});
-
+      const std::string vehicle_id;
       // clang-format off
+      try{
+         vehicle_id = common::getParameter<std::string>(node_parameters, "vehicle_id"));
+      } catch (...)
+      {
+        vehicle_id = std::to_string(common::getParameter<int>(node_parameters, "vehicle_id"));
+      }
+      if(vehicle_id != "default" && !vehicle_id.empty())
+      {
+        parameters.push_back("vehicle_id:=" + vehicle_id);
+      }
       parameters.push_back("map_path:=" + configuration.map_path.string());
       parameters.push_back("lanelet2_map_file:=" + configuration.getLanelet2MapFile());
       parameters.push_back("pointcloud_map_file:=" + configuration.getPointCloudMapFile());

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -102,6 +102,8 @@ def launch_setup(context, *args, **kwargs):
     use_custom_centerline               = LaunchConfiguration("use_custom_centerline",                  default=True)
     use_sim_time                        = LaunchConfiguration("use_sim_time",                           default=False)
     vehicle_model                       = LaunchConfiguration("vehicle_model",                          default="")
+    vehicle_id                          = LaunchConfiguration("vehicle_id",                             default="default")
+    initialize_localization             = LaunchConfiguration("initialize_localization",                default=10)
     # fmt: on
 
     print(f"architecture_type                   := {architecture_type.perform(context)}")
@@ -134,6 +136,8 @@ def launch_setup(context, *args, **kwargs):
     print(f"use_custom_centerline               := {use_custom_centerline.perform(context)}")
     print(f"use_sim_time                        := {use_sim_time.perform(context)}")
     print(f"vehicle_model                       := {vehicle_model.perform(context)}")
+    print(f"vehicle_id                          := {vehicle_id.perform(context)}")
+    print(f"initialize_localization             := {initialize_localization.perform(context)}")
 
     def make_launch_prefix():
         if enable_perf.perform(context) == "True":
@@ -164,6 +168,8 @@ def launch_setup(context, *args, **kwargs):
             {"use_custom_centerline": use_custom_centerline},
             {"use_sim_time": use_sim_time},
             {"vehicle_model": vehicle_model},
+            {"vehicle_id": vehicle_id},
+            {"initialize_localization": initialize_localization},
         ]
 
         def collect_vehicle_parameters():
@@ -232,6 +238,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("use_custom_centerline",               default_value=use_custom_centerline              ),
         DeclareLaunchArgument("use_sim_time",                        default_value=use_sim_time                       ),
         DeclareLaunchArgument("vehicle_model",                       default_value=vehicle_model                      ),
+        DeclareLaunchArgument("initialize_localization",             default_value=initialize_localization            ),
         # fmt: on
         Node(
             package="scenario_test_runner",


### PR DESCRIPTION
# Description

This PR adds support in ss2 for vehicle_id parameter and introduce initialize_localization which adds control over interval time of `/api/localization/initialize`

## Details

1. If vehicle_id parameter is specified it is added to autoware parameters.
2. initialize_localization parameter changes interval time of `/api/localization/initialize`, by default it is set to 10s.

# Destructive Changes
--

# Known Limitations
--

## References
[RJD-1907](https://tier4.atlassian.net/browse/RJD-1907)